### PR TITLE
demo using tabula-py for pdf->df, and csv->df using the pdf column names

### DIFF
--- a/Illinois PTAX.ipynb
+++ b/Illinois PTAX.ipynb
@@ -1,12 +1,24 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": 2,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "f = open('/Users/amy/Code/chi-city/Delivery Files/Data Files/2016/TRED2016PTAX203.txt')"
+    "## prerequirements\n",
+    "\n",
+    "- (https://blog.chezo.uno/tabula-py-extract-table-from-pdf-into-python-dataframe-6c7acfa5f302 \"tabula-py\")\n",
+    "\n",
+    "... ```sudo pip-3.6 install tabula-py # if you're using macports...```\n",
+    "- (https://github.com/tabulapdf/tabula-java \"tabula-java\")\n",
+    "\n",
+    "... (https://github.com/tabulapdf/tabula-java/releases/download/v1.0.1/tabula-1.0.1-jar-with-dependencies.jar \"tabula-java download\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# First we need to load the CSV metadata (column names) from the PTAX203Layout.pdf file"
    ]
   },
   {
@@ -15,23 +27,46 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "count = 0\n",
-    "for line in f.readlines():\n",
-    "    count += 1\n",
-    "    print(line.strip())\n",
-    "    if count > 1:\n",
-    "        break"
+    "from tabula import read_pdf\n",
+    "import pandas\n",
+    "\n",
+    "PTAX203Layout = '/Users/amy/Code/chi-city/Delivery Files/Data Files/2016/PTAX203Layout.pdf'\n",
+    "TRED2016PTAX203 = '/Users/amy/Code/chi-city/Delivery Files/Data Files/2016/TRED2016PTAX203.txt'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open('/Users/amy/Code/chi-city/Delivery Files/Data Files/2016/TRED2016PTAX203.txt','rb') as f:\n",
-    "          contents = f.read()\n",
-    "        #reads contents as byte file"
+    "# How to tell tabula_py to\n",
+    "# . use the first row in the PDF data as pandas.df header data\n",
+    "# . use the first column in the PDF data as pandas.df row numbers\n",
+    "pdf_to_csv_to_pandas = {\n",
+    "    'header': 0,\n",
+    "    'index_col': 0\n",
+    "}\n",
+    "\n",
+    "PTAX203_layout_df = read_pdf(PTAX203Layout, pages='all', lattice=True, pandas_options=pdf_to_csv_to_pandas)\n",
+    "PTAX203_layout_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TRED2016_df = pandas.read_csv(open(TRED2016PTAX203), names=PTAX203_layout_df['Field Name'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### O NOES !?!\n",
+    "```UnicodeDecodeError: 'utf-8' codec can't decode byte 0xad in position 181978: invalid start byte``` means there is garbage in the CSV data file :("
    ]
   },
   {

--- a/Illinois PTAX.ipynb
+++ b/Illinois PTAX.ipynb
@@ -27,8 +27,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import io, pandas\n",
     "from tabula import read_pdf\n",
-    "import pandas\n",
     "\n",
     "PTAX203Layout = '/Users/amy/Code/chi-city/Delivery Files/Data Files/2016/PTAX203Layout.pdf'\n",
     "TRED2016PTAX203 = '/Users/amy/Code/chi-city/Delivery Files/Data Files/2016/TRED2016PTAX203.txt'"
@@ -53,12 +53,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Now we need to load the CSV using column names from the layout"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "TRED2016_df = pandas.read_csv(open(TRED2016PTAX203), names=PTAX203_layout_df['Field Name'])"
+    "## This *should* work, but the data has junk that prevents it from being properly decoded :(\n",
+    "#\n",
+    "# TRED2016_df = pandas.read_csv(open(TRED2016PTAX203), names=PTAX203_layout_df['Field Name'])"
    ]
   },
   {
@@ -66,7 +75,17 @@
    "metadata": {},
    "source": [
     "### O NOES !?!\n",
-    "```UnicodeDecodeError: 'utf-8' codec can't decode byte 0xad in position 181978: invalid start byte``` means there is garbage in the CSV data file :("
+    "```UnicodeDecodeError: 'utf-8' codec can't decode byte 0xad in position 181978: invalid start byte``` means there is garbage in the CSV data file :(\n",
+    "\n",
+    "What is ```0xad```?\n",
+    "\n",
+    "```0xad``` means a binary code of ```ad``` in hexadecimal, which isn't a legal character in any UTF-8 or latin-1.\n",
+    "\n",
+    "If you punch ```ad``` into your programmer's calculator app in hex mode, and then switch to decimal and octal, we can try to look up the character in some encoding tables that list various character sets to see if there's an exotic character we can replace with an ASCII candidate.\n",
+    "\n",
+    "What I found was that ```0xad == 0255``` which looks suspiciously like the text was decoded from binary numbers as octal instead of decimal numbers because the strings where this appears look like multiple fields from some other database were accidentally put in a single field when uploaded into TRED2016PTAX203 data. ```255 == 0xff``` which is the ASCII NULL character, which by C language convention is a string terminator and field delimiter for raw binary data.\n",
+    "\n",
+    "What we should probably do is convert those ```0xad``` characters to ```:``` or something like that. Formally, everything in the affected fields including and following ```0xad``` is probably extraneous junk that should be deleted."
    ]
   },
   {
@@ -74,7 +93,49 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "TRED2016PTAX203_csv_cooked = open(TRED2016PTAX203, 'rb').read().replace(bytes([0xad]),':'.encode('ascii'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TRED2016_df = pandas.read_csv(io.BytesIO(TRED2016PTAX203_csv_cooked),\n",
+    "                              encoding='latin_1',\n",
+    "                              names=PTAX203_layout_df['Field Name'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Note:\n",
+    "We still have a problem in the data where all the strings are padded with spaces and need to be stripped of any leading or trailing whitespace.\n",
+    "\n",
+    "I'm working around that by setting up a Pandas boolean index *chicago_only* from mapping a lambda to check if the lowercased 'City or Village' column values start with 'chi'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chicago_only = TRED2016_df['City or Village'].map(lambda city: city.lower().startswith('chi'))\n",
+    "dict(zip(('rows','columns'), TRED2016_df[chicago_only].shape))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TRED2016_df[chicago_only]"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
You need to install one or two things to get this to work, and you can't get a Pandas data frame quite yet because of some garbage in the .txt csv file, but this shows how it *should* work if your csv was clean (never happens).